### PR TITLE
Update recipe names for 1.x branch

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -2,8 +2,8 @@ name: 'Saplings - Content type base'
 description: 'Shared configuration for Saplings content types.'
 type: 'Site'
 recipes:
-  - saplings-content-base-header
-  - saplings-content-base-seo
+  - saplings-fields-header
+  - saplings-fields-seo
   - saplings-media
   - saplings-theme
 install:


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [insert_ticket_name_here](insert_link_here)

> Fixes a validation error when trying to apply recipes 

```
 Validation errors were found in ../recipes/saplings-content-base/recipe.yml:  
  - [recipes][0]: The saplings-content-base-header recipe does not exist.       
  - [recipes][1]: The saplings-content-base-seo recipe does not exist. 
```

## Acceptance Criteria
Recipe uses the names: 
* saplings-fields-header
* saplings-fields-seo
Recipe applies correctly

## Steps to Validate
1. Run `fin recipe-apply ../recipes/saplings`
2. Confirm that the recipe successfully applies